### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,21 +70,15 @@ To use the published one
 
 ### Install
 
-#### Claude Desktop
+#### Option 1: Installing manually via claude_desktop_config.json config file
 
-On MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
-On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
-
-### Installing via Smithery
-
-To install Pandoc Document Conversion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-pandoc):
-
-```bash
-npx -y @smithery/cli install mcp-pandoc --client claude
-```
+- On MacOS: `open ~/Library/Application\ Support/Claude/claude_desktop_config.json`
+- On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
 <details>
   <summary>Development/Unpublished Servers Configuration</summary>
+
+  ℹ️ Replace <DIRECTORY> with your locally cloned project path
   
   ```bash
   "mcpServers": {
@@ -92,7 +86,7 @@ npx -y @smithery/cli install mcp-pandoc --client claude
       "command": "uv",
       "args": [
         "--directory",
-        "/Users/vivekvells/Desktop/code/ai/mcp-pandoc",
+        "<DIRECTORY>/mcp-pandoc",
         "run",
         "mcp-pandoc"
       ]
@@ -117,6 +111,16 @@ npx -y @smithery/cli install mcp-pandoc --client claude
   ```
 
 </details>
+
+#### Option 2: To install Published Servers Configuration automatically via Smithery
+
+Run the following bash command to install **published** [mcp-pandoc pypi](https://pypi.org/project/mcp-pandoc) for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-pandoc):
+
+```bash
+npx -y @smithery/cli install mcp-pandoc --client claude
+```
+
+**Note**: To use locally configured mcp-pandoc, follow "Development/Unpublished Servers Configuration" step above.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Officially included in the [Model Context Protocol servers](https://github.com/modelcontextprotocol/servers/blob/main/README.md) open-source project. 🎉
 
 <a href="https://glama.ai/mcp/servers/xyzzgaj9bk"><img width="380" height="200" src="https://glama.ai/mcp/servers/xyzzgaj9bk/badge" /></a>
+<a href="https://smithery.ai/server/mcp-pandoc"><img alt="Smithery Badge" src="https://smithery.ai/badge/mcp-pandoc"></a>
 
 ## Overview
 
@@ -73,6 +74,14 @@ To use the published one
 
 On MacOS: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
 On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
+
+### Installing via Smithery
+
+To install Pandoc Document Conversion for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-pandoc):
+
+```bash
+npx -y @smithery/cli install mcp-pandoc --client claude
+```
 
 <details>
   <summary>Development/Unpublished Servers Configuration</summary>


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Pandoc Document Conversion for Claude Desktop using Smithery CLI. This provides a streamlined process for users to set up the MCP.
2. Adds a badge to display the number of installations from Smithery: https://smithery.ai/server/mcp-pandoc

Feel free to suggest any modifications!