### PR TITLE
fix: prevent MCP SDK 2 startup crash (#40)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "mcp-pandoc"
-version = "0.8.1"
+version = "0.8.2"
 description = "MCP to interface with pandoc to convert files to different formats with enhanced features like Mermaid diagram conversion and defaults file support."
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
- "mcp>=1.2.1",
+ "mcp>=1.2.1,<2",
  "pyyaml>=6.0.2",
  "pandoc>=2.4",
  "pypandoc>=1.14",

--- a/src/mcp_pandoc/server.py
+++ b/src/mcp_pandoc/server.py
@@ -469,7 +469,7 @@ async def main():
             write_stream,
             InitializationOptions(
                 server_name="mcp-pandoc",
-                server_version="0.8.1",  # Universal MCP compatibility & SDK upgrade
+                server_version="0.8.2",  # Pin SDK v1 until the v2 API migration
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},

--- a/tests/test_advanced_features.py
+++ b/tests/test_advanced_features.py
@@ -311,7 +311,7 @@ class TestVersionUpdate:
             content = f.read()
 
         # Version should be updated correctly following semantic versioning
-        assert 'version = "0.8.1"' in content
+        assert 'version = "0.8.2"' in content
 
         # New dependencies should be present
         assert 'pyyaml' in content

--- a/tests/test_server_startup.py
+++ b/tests/test_server_startup.py
@@ -1,0 +1,35 @@
+"""Regression tests for the MCP server startup contract."""
+
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def test_mcp_dependency_excludes_sdk_v2():
+    """Keep fresh installs on the SDK API implemented by this release."""
+    pyproject = Path(__file__).parents[1] / "pyproject.toml"
+    dependencies = tomllib.loads(pyproject.read_text())["project"]["dependencies"]
+
+    assert "mcp>=1.2.1,<2" in dependencies
+
+
+@pytest.mark.asyncio
+async def test_stdio_server_initializes_and_lists_tool():
+    """Start the real entry point and complete the MCP handshake."""
+    params = StdioServerParameters(
+        command=sys.executable,
+        args=["-c", "from mcp_pandoc import main; main()"],
+    )
+
+    async with stdio_client(params) as streams:
+        async with ClientSession(*streams) as session:
+            initialized = await session.initialize()
+            tools = await session.list_tools()
+
+    assert initialized.serverInfo.name == "mcp-pandoc"
+    assert initialized.serverInfo.version == "0.8.2"
+    assert [tool.name for tool in tools.tools] == ["convert-contents"]

--- a/uv.lock
+++ b/uv.lock
@@ -214,7 +214,7 @@ wheels = [
 
 [[package]]
 name = "mcp-pandoc"
-version = "0.8.1"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -237,7 +237,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1.2.1" },
+    { name = "mcp", specifier = ">=1.2.1,<2" },
     { name = "pandoc", specifier = ">=2.4" },
     { name = "pandocfilters", specifier = ">=1.5.0" },
     { name = "panflute", specifier = ">=2.3.1" },


### PR DESCRIPTION
## Summary

Release the backward-compatible 0.8.2 hotfix for [issue #40](https://github.com/vivekVells/mcp-pandoc/issues/40).

### Why startup failed

The 0.8.1 package declared `mcp>=1.2.1`, which also allowed MCP Python SDK 2.x. Fresh `uvx` environments therefore began resolving SDK 2.0, while the current server still implements the SDK v1 low-level decorator API. SDK 2 removed that API, so the server crashed during import before it could complete the MCP handshake.

```text
mcp-pandoc 0.8.1: mcp>=1.2.1
        ↓ fresh resolution
MCP SDK 2.x
        ↓ v1 decorator API is unavailable
import-time crash → no MCP handshake
```

The checked-in lock file still used MCP SDK 1.x, which is why existing local and CI environments did not expose the same failure.

### How this hotfix works

- Constrains the dependency to `mcp>=1.2.1,<2`, matching the API implemented by this release.
- Bumps package and server metadata to 0.8.2.
- Adds a metadata regression test so SDK 2 cannot accidentally re-enter this release line.
- Adds a real stdio startup test that initializes a client and lists `convert-contents` through the packaged entry point.

This changes dependency resolution only. It does not change the MCP command, tool schema, conversion behavior, or existing client configuration.

### Long-term plan

Migrate the server to MCP Python SDK v2 in a separate follow-up. That change will preserve tool schemas, validation, error/result behavior, and client compatibility, with dedicated regression testing. Keeping that migration separate avoids introducing a dual-version compatibility shim into an urgent patch release.

Fixes #40.

## Essential Checklist

- [x] Tests pass locally (`uv run pytest tests/test_conversions.py`; full suite also passed)
- [x] Code follows existing patterns in `src/mcp_pandoc/server.py`
- [x] Documentation updated (not needed; client configuration is unchanged)
- [ ] Screenshots included below for visual verification — not applicable to a dependency-resolution/startup failure; executable evidence is included below

## Screenshots (Required)

This failure occurs before the stdio handshake and has no application UI. The issue contains the original traceback, and the regression test now exercises the real process boundary directly.

**For new features or format support:**
- [ ] Before/after conversion examples showing the new functionality — not applicable
- [ ] Sample input and output files — not applicable

**For bug fixes:**
- [x] Error before the fix: traceback and reproduction are captured in issue #40
- [x] Fix working correctly: clean-wheel stdio handshakes passed with MCP 1.2.1 and the newest compatible MCP 1.29.0

**For all changes:**
- [x] Proof that existing functionality still works: full regression suite passed with 89 tests passed and 27 skipped

## Verification

```text
uv lock --check                         passed
uv run ruff check .                     passed
uv run yamllint .                       passed
uv run pytest                           89 passed, 27 skipped
uv build                                sdist and wheel built
clean wheel + MCP 1.2.1                 stdio initialize/list-tools passed
clean wheel + latest compatible MCP v1  resolved 1.29.0; initialize/list-tools passed
```

The built wheel declares `Requires-Dist: mcp<2,>=1.2.1`.

## Additional Context

<details>
<summary>🔄 Format Support Changes (expand if adding/modifying formats)</summary>

No format support changes.

- [ ] New format added to `SUPPORTED_FORMATS` in server.py
- [ ] Bidirectional conversion testing included
- [ ] Test fixtures added to `tests/fixtures/`
- [ ] Conversion matrix in README.md updated
- [ ] CHEATSHEET.md examples added

</details>

<details>
<summary>⚠️ Breaking Changes (expand if applicable)</summary>

No intended breaking changes. The upper bound makes the declared dependency contract match the SDK API the server already implements.

- [x] Breaking changes clearly documented — none
- [x] Migration guide provided — not needed; client configuration is unchanged
- [x] Version bump considerations noted — patch version bumped to 0.8.2

</details>

The SDK v2 upgrade will follow as a separate compatibility-focused change after this release.
