### PR TITLE
docs: correct factual errors in the workflow audit

### DIFF
--- a/docs/audits/2026-08-agent-workflow-audit.md
+++ b/docs/audits/2026-08-agent-workflow-audit.md
@@ -6,10 +6,19 @@ Evidence behind the issues opened after [#40](https://github.com/vivekVells/mcp-
 |---|---|
 | **Prompted by** | [@pbarone's workflow description](https://github.com/vivekVells/mcp-pandoc/issues/40#issuecomment-5182935810) |
 | **Audited** | mcp-pandoc v0.9.0 (`ef3de10`) |
-| **Verified against** | pandoc 3.7.0.2, mcp python SDK 2.x, macOS |
-| **Date** | 2026-08-08 |
+| **Local toolchain** | pandoc **3.7.0.2** (released 2025-05-29), mcp python SDK 2.x, macOS |
+| **Latest pandoc at time of audit** | 3.10.1 (2026-07-22) |
+| **Date** | 2026-08-08. Revised 2026-08-08 after external review |
 
-Every finding below was reproduced by running the command shown. None are recalled or inferred.
+## Scope and limits
+
+Read this before relying on anything below.
+
+**The local pandoc used for testing is 14 months old.** Findings that say "pandoc cannot do X" are claims about **3.7.0.2 only**, and at least one of them was wrong as a general statement. Every capability claim below now carries the version it applies to. This is the main correction from review.
+
+**The project declares no minimum pandoc version.** `pyproject.toml` lists `pandoc>=2.4`, which is the PyPI package *"Pandoc Documents for Python"*, a Python library. It is **not** the pandoc binary. Nothing in the project constrains which binary a user has installed, so "is X supported" currently has no answer. See Finding 9.
+
+**Security is explicitly out of scope for this audit.** That is a deliberate exclusion, not an oversight, and it is arguably the more consequential gap: inbound documents come from third parties, the server takes arbitrary filesystem paths, and it executes user-supplied filter scripts. See [#36](https://github.com/vivekVells/mcp-pandoc/issues/36) and [#33](https://github.com/vivekVells/mcp-pandoc/issues/33). Those deserve their own audit against the same workflow.
 
 ---
 
@@ -31,7 +40,7 @@ It runs as an MCP server rather than CLI calls because conversion is one step in
 
 ---
 
-## Finding 1: pandoc cannot read PDF, but the schema offers it
+## Finding 1: pandoc has no PDF reader, but the schema offers `pdf` as input
 
 `input_format` includes `pdf` at [`server.py:114`](../../src/mcp_pandoc/server.py#L114).
 
@@ -39,64 +48,102 @@ It runs as an MCP server rather than CLI calls because conversion is one step in
 $ pandoc -f pdf b.pdf -t markdown
 Unknown input format pdf
 Pandoc can convert to PDF, but not from PDF.
+```
 
-$ pandoc --list-input-formats | grep -c pdf
+**Version scope.** Checked the last 25 pandoc releases for any that added a PDF reader. None did. Unlike Finding 2, this is a general statement, not a property of 3.7.0.2.
+
+**Impact.** The input schema is a promise made to a language model. A model reading `pdf` in the enum will attempt PDF input, fail, and often retry the same call. Failures are clean rather than data-corrupting, so this is **P1, not P0**.
+
+Tracked in [#47](https://github.com/vivekVells/mcp-pandoc/issues/47).
+
+---
+
+## Finding 2: pandoc CAN read pptx since 3.8.3. This audit originally said otherwise, and was wrong
+
+**Original claim, now retracted:** "Pandoc has no pptx reader, so pptx to markdown is impossible."
+
+**Correction.** Pandoc **3.8.3**, released 2025-12-01, added a native PowerPoint reader:
+
+> `Add `pptx` (PowerPoint) as new input format (Anton Antich).`
+> `New module `Text.Pandoc.Readers.Pptx`, exporting `readPptx``
+
+Verified against the pandoc release notes via the GitHub releases API. The same release added `asciidoc` and `xlsx` readers.
+
+```console
+# pandoc 3.7.0.2 (the version tested locally)
+$ pandoc -f pptx deck.pptx -t markdown
+Unknown input format pptx
+
+# pandoc >= 3.8.3
+pptx is a supported input format.
+```
+
+**What this means.**
+
+| | |
+|---|---|
+| The user's inbound pptx step | **Works**, if he has pandoc 3.8.3 or newer. It was never impossible |
+| Our exposure of pptx | Neither input nor output is exposed, in any pandoc version |
+| The blocker | We cannot say "pptx input is supported" until the project declares a minimum pandoc version. See Finding 9 |
+| `python-pptx` | **No longer relevant.** The original conclusion that a non-pandoc dependency would be required is withdrawn |
+
+**Root cause of the error.** Testing against a 14-month-old local binary and reporting the result as a permanent property of pandoc rather than of that binary.
+
+---
+
+## Finding 3: format support is directional, and the schema presents it as symmetric
+
+The principle holds. The matrix in the original audit did not, and is corrected here.
+
+Both `input_format` and `output_format` use the same ten-value enum, which tells the model that anything readable is writable and vice versa.
+
+| Format | Native reader | Native writer | Notes |
+|---|---|---|---|
+| markdown | yes | yes | |
+| html | yes | yes | |
+| docx | yes | yes | |
+| odt | yes | yes | |
+| rst | yes | yes | |
+| latex | yes | yes | |
+| epub | yes | yes | |
+| ipynb | yes | yes | |
+| **txt** | **NO** | via alias | See Finding 4. Not a pandoc format in either direction |
+| **pdf** | **NO** | yes | Write-only. No reader in any release |
+| **pptx** | **>= 3.8.3** | yes | Not exposed by this project in either direction |
+
+The relevant distinction is four-way, not two-way: **native reader**, **native writer**, **project alias or extension inference**, and **minimum pandoc version**.
+
+---
+
+## Finding 4: `input_format: "txt"` fails, and the schema offers it
+
+Not in the original audit. Found during review.
+
+`txt` is not a pandoc format in either direction. [`server.py:177`](../../src/mcp_pandoc/server.py#L177) translates it to `plain` **for output only**. There is no equivalent translation for input.
+
+```console
+$ pandoc --list-input-formats | grep -cx "txt"
 0
 ```
 
-**Impact.** The input schema is a promise made to a language model. A model reading `pdf` in the enum will attempt PDF input confidently, fail, and often retry the same impossible call. A human reading CLI `--help` would simply try something else.
-
-Tracked in the `pdf` input enum issue.
-
----
-
-## Finding 2: pandoc cannot read pptx, and can write it
+Against the running server:
 
 ```console
-$ pandoc --list-output-formats | grep -w pptx
-pptx
-
-$ pandoc -f pptx deck.pptx -t markdown
-Unknown input format pptx
+$ contents="hello world", input_format="txt", output_format="html"
+Error converting contents from txt to html: Invalid input format! Got "txt"
+but expected one of these: biblatex, bibtex, bits, commonmark, ...
 ```
 
-**Impact.** The user's inbound `.pptx → markdown` step cannot work with pandoc, and nothing in the schema or docs says so. Separately, pptx **output** is a pandoc capability the server does not expose.
+**Why it looks like it works.** `.txt` **files** convert fine, because the `input_file` branch at [`server.py:359`](../../src/mcp_pandoc/server.py#L359) never passes `input_format` to pypandoc. Pandoc infers from the extension and falls back to markdown. So the parameter is silently ignored on the file path and hard-fails on the inline-content path.
 
-Implementing a pptx reader would require `python-pptx`, a non-pandoc dependency, which is a red-light item under the project philosophy in [`CLAUDE.md`](../../CLAUDE.md).
-
-Tracked in the pptx output-only issue.
+Two defects in one: an enum value that cannot work, and a parameter that is ignored in one branch and honoured in the other.
 
 ---
 
-## Finding 3: read and write format support are not symmetric
-
-The same ten-value enum backs both `input_format` and `output_format`, which tells the model that anything readable is writable and vice versa.
-
-```
-              READ    WRITE
-   markdown    yes     yes
-   html        yes     yes
-   docx        yes     yes
-   odt         yes     yes
-   rst         yes     yes
-   latex       yes     yes
-   epub        yes     yes
-   ipynb       yes     yes
-   txt         yes     yes
-   pdf         NO      yes     ← write-only
-   pptx        NO      yes     ← write-only, and not currently exposed
-```
-
-This is the root pattern behind findings 1 and 2, not two separate bugs.
-
----
-
-## Finding 4: docx to markdown silently drops embedded images
+## Finding 5: docx to markdown silently drops embedded images
 
 ```console
 $ pandoc img.docx -t markdown
-# T
-
 ![alt text](media/rId9.png){width="..." height="..."}
                 ^^^^^^^^^^^^ referenced, but never written to disk
 
@@ -105,106 +152,147 @@ $ ls media/media
 rId9.png                      ← now it exists
 ```
 
-`--extract-media` is not exposed by the server, and there is no way to reach it except through a `defaults_file`.
+`--extract-media` is not exposed and is reachable only through a `defaults_file`.
 
-**Impact.** On the inbound path, an agent converting a Word document receives broken image links **with no error and no warning**. It cannot detect that content is missing, so it reasons over an incomplete document and does not know it. Silent data loss is worse than a failed conversion.
+**Impact.** An agent converting an inbound Word document receives broken image links **with no error and no warning**. It cannot detect that content is missing, so it reasons over an incomplete document and does not know it.
 
-Tracked in the `extract_media` issue.
+**Evidence gap, from review.** This was reproduced with a synthetic one-pixel PNG embedded in a generated docx. No representative fixture is committed, so the result cannot be independently re-run. A real-world docx fixture should be added before designing the fix.
+
+**On the API question.** Review raised that a ninth parameter conflicts with the "eight parameter" contract. It does not. `additionalProperties: false` rejects properties *clients send that we do not know*. Adding a new optional property to the published schema is additive and backwards compatible. The contract is about not removing or renaming. The open design question is whether extraction should be implicit or explicit, and where files land, not whether a parameter may be added.
+
+Tracked in [#48](https://github.com/vivekVells/mcp-pandoc/issues/48).
 
 ---
 
-## Finding 5: `reference_doc` is gated more narrowly than pandoc requires
+## Finding 6: `reference_doc` is gated more narrowly than pandoc requires
 
 [`server.py:188`](../../src/mcp_pandoc/server.py#L188) rejects `reference_doc` unless output is `docx`. Pandoc's `--reference-doc` applies to docx, odt, and pptx.
 
 ```console
-$ pandoc a.md -o r.odt && pandoc a.md --reference-doc=r.odt -o out.odt
-ODT REFDOC OK
-
-$ pandoc a.md -o ref.pptx && pandoc a.md --reference-doc=ref.pptx -o out2.pptx
-PPTX REFDOC OK
+$ pandoc a.md -o r.odt && pandoc a.md --reference-doc=r.odt -o out.odt      # succeeds
+$ pandoc a.md -o ref.pptx && pandoc a.md --reference-doc=ref.pptx -o out2.pptx  # succeeds
 ```
 
-**Impact.** `reference_doc` is the parameter the reporter singled out as load-bearing, "the difference between a docx and a docx someone will actually accept". The same argument applies to a branded deck or an ODT house style. The restriction is ours.
+Verified on 3.7.0.2, and this scope has been stable across releases.
+
+**Impact.** `reference_doc` is the parameter the reporter singled out as load-bearing, "the difference between a docx and a docx someone will actually accept". The same argument applies to a branded deck or an ODT house style. The restriction is ours, not pandoc's.
+
+Tracked in [#52](https://github.com/vivekVells/mcp-pandoc/issues/52).
 
 ---
 
-## Finding 6: server-side warnings reach nobody
+## Finding 7: bare `print()` for diagnostics, and the fix is stderr, not MCP logging
 
 Four bare `print()` calls remain: [`server.py:209`](../../src/mcp_pandoc/server.py#L209), [`:280`](../../src/mcp_pandoc/server.py#L280), [`:282`](../../src/mcp_pandoc/server.py#L282), [`:285`](../../src/mcp_pandoc/server.py#L285).
 
-**They are not corrupting the protocol today.** Verified by reading the SDK source: `mcp/server/stdio.py` takes a private duplicate of fd 1 for the wire and re-points fd 1 itself at stderr, so `print()` lands harmlessly on stderr.
+**They are not corrupting the protocol.** Verified by reading the SDK source: `mcp/server/stdio.py` takes a private duplicate of fd 1 for the wire and re-points fd 1 itself at stderr, so `print()` lands on stderr. There are documented fallback paths where the diversion is not established and the stream is served in place; on those, a stray `print()` would splice non-JSON into a stream the client parses strictly.
 
-Two reasons to change them anyway:
+**Correction from review: do not migrate to MCP logging notifications.** The original audit recommended `notifications/message`. That is now against spec guidance. From the [2026-07-28 logging specification](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging):
 
-1. **Nobody sees them.** The MCP spec says clients MAY ignore stderr, and most do. A warning that reaches no one is not a warning.
-2. **The safety net has documented fallback paths.** When the SDK cannot establish the diversion it serves the stream in place, exactly as v1 did. On that path a stray `print()` splices non-JSON into a stream the client parses strictly, and the connection wedges.
+> **Deprecated**: The Logging feature is deprecated as of protocol version `2026-07-28` ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)). [...] New implementations **SHOULD NOT** adopt it; existing implementations **SHOULD** migrate to logging to `stderr` for stdio transports, or to [OpenTelemetry](https://opentelemetry.io/) for structured observability.
 
-The SDK exposes `LoggingCapability` and `LoggingMessageNotification` for this.
+**Also corrected:** the original audit asserted "most clients ignore stderr". That was unsupported. What the spec actually says is that clients **MAY** capture, forward, or ignore stderr, and current MCP debugging guidance says stdio hosts capture it.
+
+**Revised recommendation, split by audience:**
+
+| Audience | Channel |
+|---|---|
+| The model, for anything affecting the result | Include it in the tool result text. Dropped media, ignored parameters, format fallbacks |
+| A human debugging | `logging` module to stderr, with levels. Not `print()` |
+| Neither | Delete the message |
+
+Tracked in [#50](https://github.com/vivekVells/mcp-pandoc/issues/50), which needs redesign along these lines.
 
 ---
 
-## Finding 7: CI cannot see what a new user sees
+## Finding 8: CI does not install the way users install
 
-This is the root cause of #40, not a contributing factor.
+**Corrected causality.** The root cause of #40 was the **uncapped `mcp` dependency**. Lockfile-based CI was a **detection gap**, not the cause. The original audit conflated the two.
 
 ```
   CI                                  A real user
   ──                                  ───────────
   uv sync  → installs uv.lock         uvx  → fresh resolve, newest allowed
-    └─ pinned mcp 1.x forever           └─ picked up mcp 2.0.0 → crash on import
+    └─ stayed on mcp 1.x                └─ resolved to mcp 2.0.0 → crash on import
 ```
 
-`uv sync` installs the pinned lockfile. `uvx` resolves fresh. **Different programs, and only one was tested.**
+**Corrected timeline.** The original audit claimed every fresh install was broken for eleven months. That is false.
 
-### Why a PR check alone would not have caught it
+| Event | Date | Source |
+|---|---|---|
+| v0.8.1 released | 2025-08-29 | git tag |
+| Last commit before the gap | 2025-09-15 | git log |
+| **mcp 2.0.0 released** | **2026-07-28** | [PyPI](https://pypi.org/project/mcp/2.0.0/) |
+| #40 filed | 2026-07-29 | GitHub |
+| v0.8.2 fix shipped | 2026-07-31 | git tag |
 
-```
-  2025-08-29   v0.8.1 released ────┐
-                                   │  ELEVEN MONTHS. Zero commits, zero PRs.
-               mcp 2.0.0 ships ────┤  Every fresh install broken the whole time.
-               issue #40 filed ────┤
-  2026-07-31   v0.8.2 shipped ─────┘
-```
+**The break window was approximately three days, not eleven months.** The quiet period in the repo was real, roughly ten months with no commits from 2025-09-15, but the two are separate facts and the original audit merged them. It also incorrectly stated there were zero commits after v0.8.1; there were 11, through 2025-09-15.
 
-Verified from `git log`. A PR check fires only when someone pushes, and nothing was pushed for eleven months. Both triggers are needed:
+**An honest consequence for the scheduled-job recommendation.** Users reported this within one day of the break. A weekly scheduled check would average 3.5 days and would have been **slower than the community**. The argument for scheduled fresh-resolution testing is therefore not "it would have caught #40 sooner". It is that it gives detection you control, for breaks that are subtler than a startup crash and that users may never report. That is a weaker claim than the original audit made, and it should be stated as the weaker claim.
 
-| Trigger | Catches |
-|---|---|
-| On PR | breaks we introduce, plus upstream breaks current at that moment |
-| On schedule | upstream breaks during quiet periods ← the #40 window |
+**Platform coverage.** CI runs `ubuntu-latest` and Python 3.11 only. `requires-python` is `>=3.11`, so 3.12 and 3.13 are untested. @pbarone reported Windows 11 with Python 3.13. @Andrea-encrypted reported Windows without specifying a Python version. The original audit's "both reporters on Windows 11 and Python 3.13" overstated the second report.
 
-### Platform coverage
-
-CI runs `ubuntu-latest` and Python 3.11 only. Both reporters of #40 were on **Windows 11 with Python 3.13**. `requires-python` is `>=3.11`, so 3.12 and 3.13 are supported and untested. The SDK contains Windows-specific stdio handle code that CI never executes.
+Tracked in [#45](https://github.com/vivekVells/mcp-pandoc/issues/45) and [#46](https://github.com/vivekVells/mcp-pandoc/issues/46).
 
 ---
 
-## Finding 8: startup crashes are structurally invisible
+## Finding 9: no minimum pandoc binary version is declared
+
+Not in the original audit. This is the blocker for Finding 2 and it makes several capability questions unanswerable.
+
+```toml
+dependencies = [
+  "pandoc>=2.4",     # ← the PyPI package "Pandoc Documents for Python", a Python library
+  "pypandoc>=1.14",  # ← wrapper that shells out to the binary
+]
+```
+
+Neither constrains the **pandoc binary** the user has installed. Consequences:
+
+- "Does mcp-pandoc support pptx input" has no answer. It depends on a binary version we neither declare nor check.
+- A user on pandoc 2.x and a user on 3.10.1 get materially different capabilities from the same server version, with no signal about why.
+- Enum values cannot be gated on capability, because capability is unknown at startup.
+
+Until a minimum is declared and checked, any format-support claim in the README is conditional on something unstated.
+
+---
+
+## Finding 10: startup crashes cannot be reported through MCP
 
 Reported by the user:
 
 > What made this bug hard to spot from the client side is that an import-time crash is completely silent, my agent just showed the server as not connecting, with no logs.
 
-He is right, and it is not fixable in the server. The crash happens before the MCP session exists, so there is no protocol channel to report on. Python's traceback goes to stderr, and the [spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports) states:
+Accurate as far as the protocol goes. The crash happens before the MCP session exists, so there is no protocol channel to report on.
 
-> The server **MAY** write UTF-8 strings to its standard error (`stderr`) for logging purposes. Clients **MAY** capture, forward, or ignore this logging.
+**Qualified from review.** The traceback does reach stderr, and current MCP debugging guidance says stdio hosts capture stderr. So the failure is not universally invisible; it was invisible in the client he was using. A diagnostics command is **optional product work**, not a necessary consequence of the transport design. `--version` and better troubleshooting docs are the smaller first step.
 
-What can be improved is diagnosis cost. `__init__.py` currently has no argument handling at all, so `mcp-pandoc --version` silently starts a server and hangs.
+`__init__.py` currently has no argument handling, so `mcp-pandoc --version` silently starts a server and hangs.
+
+Tracked in [#51](https://github.com/vivekVells/mcp-pandoc/issues/51).
 
 ---
 
 ## Summary
 
-| # | Finding | Severity | Nature |
+| # | Finding | Priority | Confidence |
 |---|---|---|---|
-| 7 | CI does not install the way users install | P0 | Process. Caused #40 |
-| 7 | CI covers neither Windows nor Python 3.13 | P0 | Process |
-| 1 | `pdf` offered as an input format | P0 | Impossible promise to the model |
-| 4 | docx→md silently drops images | P1 | Silent data loss |
-| 2 | pptx output not exposed; pptx input impossible | P1 | Missing capability + invisible limit |
-| 6 | Warnings reach nobody | P1 | Observability |
-| 8 | Startup crashes invisible | P2 | Transport limit; reduce diagnosis cost |
-| 5 | `reference_doc` gated to docx only | P2 | Unnecessary restriction |
+| 9 | No minimum pandoc version declared | P0 | Verified. Blocks 2 and 3 |
+| 8 | CI does not install the way users install | P1 | Verified. Weaker rationale than originally stated |
+| 8 | CI covers neither Windows nor Python 3.13 | P1 | Verified |
+| 5 | docx to markdown silently drops images | P1 | Verified. Needs a committed fixture |
+| 4 | `input_format: "txt"` fails; ignored on the file branch | P1 | Verified against the running server |
+| 1 | `pdf` offered as an input format | P1 | Verified across all releases |
+| 2 | pptx supported by pandoc >= 3.8.3, exposed by us in neither direction | P2 | Verified. **Corrects the original audit** |
+| 7 | Diagnostics via `print()` | P2 | Verified. Fix is stderr, not MCP logging |
+| 6 | `reference_doc` gated to docx only | P2 | Verified |
+| 10 | Startup crashes invisible in some clients | P3 | Qualified |
 
-Findings 1, 2, and 3 are the same underlying issue: **format support is directional, and the schema presents it as symmetric.**
+**Out of scope and unaddressed:** the trust boundary. Inbound documents originate from third parties, the server accepts arbitrary filesystem paths, and it executes user-supplied filter scripts. See [#36](https://github.com/vivekVells/mcp-pandoc/issues/36) and [#33](https://github.com/vivekVells/mcp-pandoc/issues/33).
+
+## Revision history
+
+| Date | Change |
+|---|---|
+| 2026-08-08 | Initial audit |
+| 2026-08-08 | Revised after external review. Retracted the pptx impossibility claim (pandoc 3.8.3 added a reader). Corrected the #40 timeline from eleven months to roughly three days and separated root cause from detection gap. Corrected the format matrix and added the `txt` reader defect. Reversed the MCP logging recommendation, now deprecated by spec. Added the missing minimum-pandoc-version finding. Scoped out security explicitly. Corrected the environment claim about the second reporter. |


### PR DESCRIPTION
Follow-up to #53, which is already merged. **Several load-bearing claims in that audit are wrong and are currently live on `main`.** This PR corrects them and states the retractions in the document rather than quietly editing them out.

Every correction below was re-verified from a primary source before being written.

## The pptx error, the serious one

The merged audit claims pandoc cannot read pptx, and that a `python-pptx` dependency would be required to support it. **Both are wrong.**

Pandoc **3.8.3**, released 2025-12-01, added a native PowerPoint reader:

> `Add `pptx` (PowerPoint) as new input format (Anton Antich).`
> `New module `Text.Pandoc.Readers.Pptx`, exporting `readPptx``

The claim came from testing a local pandoc **3.7.0.2**, which is 14 months old, and reporting the result as a permanent property of pandoc rather than of that binary. Every capability claim in the audit now carries the version it applies to.

This matters beyond the audit: it was repeated to a user as "your workflow step cannot work", when it may already work on a current pandoc.

## The #40 timeline

The merged audit claims every fresh install was broken for eleven months.

| Event | Date | Source |
|---|---|---|
| mcp 2.0.0 released | 2026-07-28 | [PyPI](https://pypi.org/project/mcp/2.0.0/) |
| #40 filed | 2026-07-29 | GitHub |
| v0.8.2 shipped | 2026-07-31 | git tag |

**The break window was roughly three days.** The quiet period in the repo was real, but it is a separate fact and the two were merged. The audit also claimed zero commits after v0.8.1; there were 11, through 2025-09-15. The original check used `git log --simplify-by-decoration`, which shows only tagged commits.

Causality is corrected too: the **uncapped dependency** was the root cause, and lockfile-based CI was a **detection gap**, not the cause.

Consequence for the recommendation: users reported the break within one day, so a weekly scheduled check would have been *slower than the community*. The scheduled-CI argument is now stated as the weaker claim it actually is.

## The logging reversal

The merged audit recommends migrating to MCP logging notifications. That is against current spec guidance. From the [2026-07-28 logging specification](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/logging):

> **Deprecated**: The Logging feature is deprecated as of protocol version `2026-07-28` ([SEP-2577](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2577)). [...] New implementations **SHOULD NOT** adopt it; existing implementations **SHOULD** migrate to logging to `stderr` for stdio transports.

Recommendation reversed and split by audience: tool result for anything the model needs to react to, stderr logging for humans. The unsupported "most clients ignore stderr" claim is withdrawn.

## Two new findings

- **`input_format: "txt"` fails on the inline-content branch** and is silently ignored on the file branch, because that branch never passes the format to pypandoc. Two defects: an enum value that cannot work, and a parameter honoured in one code path and discarded in the other. Filed as #57.
- **No minimum pandoc binary version is declared.** `pyproject.toml` lists `pandoc>=2.4`, which is the PyPI Python library *"Pandoc Documents for Python"*, not the binary. This makes "is format X supported" unanswerable and blocks the pptx work. Filed as #54.

## Scope

Security is now **explicitly declared out of scope** rather than silently omitted. Inbound documents come from third parties, the server accepts arbitrary filesystem paths, and it executes user-supplied filter scripts. See #36 and #33. That is arguably more consequential than anything the audit covers.

## Also corrected

| Claim | Correction |
|---|---|
| "Both reporters on Windows 11 with Python 3.13" | Only @pbarone gave both. @Andrea-encrypted reported Windows without a Python version |
| Format matrix listed `txt` as readable | `txt` is not a pandoc reader in either direction |
| `pdf` input impossible | **Unchanged.** Re-verified across the last 25 releases; no PDF reader was ever added |

## Dependent issues

#44, #45, #46, #47, #48, #49, #50, #51 have all been updated to match, each carrying a visible revision note. New issues #54, #55, #56, #57 were opened.

## Notes

- Docs only. One file. No source or test changes.
- The pattern behind most of these errors was the same: testing against a stale local binary and stating the result as a general truth.