### PR TITLE
ci: add Windows and Python 3.13 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ name: Build & Test
     branches: [main, master]
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -21,9 +21,6 @@ jobs:
 
     - name: Install uv
       run: pip install uv
-
-    - name: Install Pandoc and TeX Live
-      run: sudo apt-get update && sudo apt-get install -y pandoc texlive-xetex
 
     - name: Sync dependencies (all groups)
       run: uv sync --all-groups
@@ -39,6 +36,37 @@ jobs:
     - name: Run pre-commit
       run: uv run pre-commit run --all-files
 
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.11", "3.13"]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set up Pandoc
+      uses: r-lib/actions/setup-pandoc@v2
+
+    # TeX is only needed to render PDF; PDF tests skip cleanly without an engine,
+    # so we install it on Linux only rather than pay the cost on every runner.
+    - name: Install TeX Live (Linux only)
+      if: runner.os == 'Linux'
+      run: sudo apt-get update && sudo apt-get install -y texlive-xetex
+
+    - name: Install uv
+      run: pip install uv
+
+    - name: Sync dependencies (all groups)
+      run: uv sync --all-groups
+
     - name: Run pytest
       run: uv run pytest
 
@@ -46,14 +74,14 @@ jobs:
       run: uv build
 
     - name: Test server imports
-      run: uv run python -c "import mcp_pandoc; print('✅ Server imports correctly')"
-      # run: |
-      #   # MCP servers are stdio-based and block waiting for JSON-RPC input
-      #   # A successful timeout means the server started and was running correctly
-      #   timeout 3 uv run mcp-pandoc >/dev/null 2>&1
-      #   if [ $? -eq 124 ]; then  # 124 is timeout's exit code when process is killed
-      #       echo "✅ MCP server starts and runs correctly"
-      #   else
-      #       echo "❌ MCP server failed to start or crashed"
-      #       exit 1
-      #   fi
+      run: uv run python -c "import mcp_pandoc; print('Server imports correctly')"
+
+  # Single stable check to require in branch protection: green only when lint and
+  # every matrix leg of test pass.
+  ci-ok:
+    name: CI OK
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+    - name: All checks passed
+      run: echo "lint and the full test matrix passed"

--- a/tests/test_conversions.py
+++ b/tests/test_conversions.py
@@ -1,6 +1,20 @@
 import pypandoc
 import os
+import shutil
 import pytest
+
+# pandoc renders PDF through an external engine (a TeX distribution by default).
+# Without one installed, PDF conversion cannot run — so those cases are skipped
+# rather than failed. This keeps CI green on jobs that install pandoc but not a
+# heavy TeX distribution (e.g. the Windows matrix job).
+_PDF_ENGINES = (
+    "pdflatex", "xelatex", "lualatex", "tectonic", "wkhtmltopdf",
+    "weasyprint", "prince", "context", "pagedjs-cli", "typst",
+)
+
+
+def _pdf_engine_available() -> bool:
+    return any(shutil.which(engine) for engine in _PDF_ENGINES)
 
 # Define paths
 FIXTURE_DIR = os.path.join(os.path.dirname(__file__), 'fixtures')
@@ -41,6 +55,11 @@ def test_bidirectional_conversions(from_format, to_format):
     # For this test, we will only test converting *to* pdf from markdown
     if to_format == 'pdf' and from_format != 'md':
         pytest.skip("Skipping conversion to PDF from formats other than markdown for this test.")
+
+    # PDF output needs a rendering engine (TeX etc.). Skip cleanly when none is
+    # installed instead of failing — e.g. a Windows job with pandoc but no TeX.
+    if to_format == 'pdf' and not _pdf_engine_available():
+        pytest.skip("Skipping PDF conversion: no PDF engine (e.g. a TeX distribution) is installed.")
 
     input_file = os.path.join(FIXTURE_DIR, f'test.{from_format}')
     output_file = os.path.join(OUTPUT_DIR, f'test.{to_format}')


### PR DESCRIPTION
Closes #45.

CI only ran `ubuntu-latest` + Python 3.11, while `requires-python` is `>=3.11` — so Windows and 3.13 (the environment #40 was reported on) went untested.

## Changes
- **Matrix**: split into a `lint` job (ubuntu / 3.11) and a `test` job over `{ubuntu-latest, windows-latest} × {3.11, 3.13}`. Pandoc is installed cross-platform via `r-lib/actions/setup-pandoc`.
- **PDF without TeX**: PDF conversions now **skip cleanly** when no PDF engine is installed (`shutil.which` over pandoc's known engines) rather than failing. TeX Live is installed on Linux only, so the Windows legs — which don't carry a TeX distribution — stay green. *(Acceptance criterion: "PDF tests skip cleanly where no TeX engine is present.")*
- **Required check**: added a `ci-ok` aggregation job (`needs: [lint, test]`) as one stable check to require in branch protection.

## Verification
Environment: macOS (Apple Silicon), Python 3.11, pandoc 3.9.0.2, **no TeX installed**.

```
$ uv run pytest -q
127 passed, 40 skipped

$ uv run pytest 'tests/test_conversions.py::test_bidirectional_conversions[pdf-md]' -rs
SKIPPED tests/test_conversions.py:62: Skipping PDF conversion: no PDF engine (e.g. a TeX distribution) is installed.

$ uv run yamllint .github/workflows/ci.yml     # exit 0
$ uv run ruff check .                           # All checks passed!
$ uv run pre-commit run --files .github/workflows/ci.yml tests/test_conversions.py   # all Passed
```

**Could not verify locally:** the `windows-latest` and Python `3.13` matrix legs (no Windows machine / that interpreter here). Those — including the `test_server_startup.py` handshake on Windows — are verified by this PR's CI run. Since #40's root cause was the uncapped `mcp` SDK dependency (now fixed on the SDK-v2 path), there shouldn't be a Windows-specific startup blocker, but the CI is the source of truth.

**For the maintainer:** marking the check *required* is a branch-protection setting; `ci-ok` gives you one stable name to require rather than pinning each matrix leg.
